### PR TITLE
fix(fourth) copy styles from bootstrap

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,7 +1,7 @@
 CKEDITOR.plugins.add( 'bylawlist', {
     onLoad: function() {
       CKEDITOR.addCss(
-        'ol.bylawlist,ol.bylawlist>li,ol.bylawlist>li ol>li,ol.bylawlist>li ol>li ol>li, ol.bylawlist>li ol>li ol>li ol>li{list-style-type:none;list-style-position:inside}ol.bylawlist{padding-left:1.5em}ol.bylawlist>li{counter-increment:first}ol.bylawlist>li:before{content:"(" counter(first,decimal) ") "}ol.bylawlist>li ol>li{counter-increment:second}ol.bylawlist>li ol>li:before{content:"(" counter(second,lower-alpha) ") "}ol.bylawlist>li ol>li ol>li{counter-increment:third}ol.bylawlist>li ol>li ol>li:before{content:"(" counter(third,lower-roman) ") "}ol.bylawlist>li ol>li ol>li ol>li{counter-increment:fourth}ol.bylawlist>li ol>li ol>li ol>li:before{content:"(" counter(fourth, decimal) "." counter(first, decimal) ") "}'
+        'ol.bylawlist{list-style-type:none;list-style-position:inside;padding-left:1.5em}ol.bylawlist>li>ol,ol.bylawlist>li>ol>li>ol{list-style-type:inherit}ol.bylawlist li{counter-increment:bylawlist-counter}ol.bylawlist li:first-child{counter-reset:bylawlist-counter}ol.bylawlist>li:before{content:"(" counter(bylawlist-counter,decimal) ") "}ol.bylawlist>li>ol>li:before{content:"(" counter(bylawlist-counter,lower-alpha) ") "}ol.bylawlist>li>ol>li>ol>li:before{content:"(" counter(bylawlist-counter,lower-roman) ") "}ol.bylawlist>li>ol>li>ol>li>ol{list-style-type:decimal}ol.bylawlist>li>ol>li>ol>li>ol>li:before{content:none}'
       );
     },
     icons: 'bylawlist', // Bylaw List icon


### PR DESCRIPTION
The styles from ottawa bootstrap need to be copied into the plugin for it to work in the editor. Missed this push when prepping the bylawlist.

See https://github.com/CityofOttawa/ottawa_profile/issues/2221