### PR TITLE
Issue 2244 - fix(editor) add observer in chrome

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,36 +1,65 @@
 CKEDITOR.plugins.add( 'bylawlist', {
-    onLoad: function() {
-      CKEDITOR.addCss(
-        'ol.bylawlist,ol.bylawlist>li,ol.bylawlist>li ol>li,ol.bylawlist>li ol>li ol>li, ol.bylawlist>li ol>li ol>li ol>li{list-style-type:none;list-style-position:inside}ol.bylawlist{padding-left:1.5em}ol.bylawlist>li{counter-increment:first}ol.bylawlist>li:before{content:"(" counter(first,decimal) ") "}ol.bylawlist>li ol>li{counter-increment:second}ol.bylawlist>li ol>li:before{content:"(" counter(second,lower-alpha) ") "}ol.bylawlist>li ol>li ol>li{counter-increment:third}ol.bylawlist>li ol>li ol>li:before{content:"(" counter(third,lower-roman) ") "}ol.bylawlist>li ol>li ol>li ol>li{counter-increment:fourth}ol.bylawlist>li ol>li ol>li ol>li:before{content:"(" counter(fourth, decimal) "." counter(first, decimal) ") "}'
-      );
-    },
-    icons: 'bylawlist', // Bylaw List icon
-    init: function( editor ) {
-        editor.addCommand( 'insertBylawlist', {
-            exec: function( editor ) {
-              if ('li' == editor.getSelection().getStartElement().getName()) {  
-                if ('OL' == editor.getSelection().getStartElement().$.parentNode.nodeName) {
-                  var bylaw = editor.getSelection().getStartElement().$.parentNode;
-                  if(bylaw.className.indexOf("bylawlist") < 0){
-                     bylaw.className += "bylawlist";
-                  } 
-                  else {
-                    bylaw.className = "";
-                  }
-                  
-                }              
+  onLoad: function() {
+    CKEDITOR.addCss(
+      'ol.bylawlist{list-style-type:none;list-style-position:inside;padding-left:1.5em}ol.bylawlist>li>ol,ol.bylawlist>li>ol>li>ol{list-style-type:inherit}ol.bylawlist li{counter-increment:bylawlist-counter}ol.bylawlist li:first-child{counter-reset:bylawlist-counter}ol.bylawlist>li:before{content:"(" counter(bylawlist-counter,decimal) ") "}ol.bylawlist>li>ol>li:before{content:"(" counter(bylawlist-counter,lower-alpha) ") "}ol.bylawlist>li>ol>li>ol>li:before{content:"(" counter(bylawlist-counter,lower-roman) ") "}ol.bylawlist>li>ol>li>ol>li>ol{list-style-type:decimal}ol.bylawlist>li>ol>li>ol>li>ol>li:before{content:none}'
+    );
+  },
+  icons: 'bylawlist', // Bylaw List icon
+  init: function( editor ) {
+      editor.addCommand( 'insertBylawlist', {
+          exec: function( editor ) {
+            if ('li' == editor.getSelection().getStartElement().getName()) {
+              if ('OL' == editor.getSelection().getStartElement().$.parentNode.nodeName) {
+                var bylaw = editor.getSelection().getStartElement().$.parentNode;
+                if(bylaw.className.indexOf("bylawlist") < 0){
+                   bylaw.className += "bylawlist";
+                }
+                else {
+                  bylaw.className = "";
+                }
               }
             }
-       });
-        editor.ui.addButton( 'Bylawlist', {
-            label: 'Add Bylawlist',
-            command: 'insertBylawlist',
-            toolbar: 'insert'
+          }
+     });
+    editor.ui.addButton( 'Bylawlist', {
+        label: 'Add Bylawlist',
+        command: 'insertBylawlist',
+        toolbar: 'insert'
+    });
+    var format = {'element': 'Bylawlist'};
+    var style = new CKEDITOR.style(format);
+    editor.attachStyleStateChange( style, function( state ) {
+      !editor.readOnly && editor.getCommand( 'insertBylawlist' ).setState( state );
+    });
+
+    editor.on('contentDom', () => {
+      /**
+       * Updates all list starting points.
+       *
+       * @param {object} obj the list object.
+       */
+      function updateList(obj) {
+        jQuery(obj).find('li').first().css('counter-reset', 'bylawlist-counter ' + (jQuery(obj).attr('start') - 1));
+      }
+
+      const lists = editor.document.find('ol[start]');
+
+      jQuery(lists).each((index, obj) => {
+        updateList(obj.$);
+      });
+
+      const observerTarget = editor.document.find('html').$[0];
+      const observerConfig = { attributes: true, subtree: true };
+      const observerCallback = (mutationsList, observer) => {
+        mutationsList.forEach((mutation) => {
+            if (mutation.attributeName == 'start') {
+              updateList(mutation.target)
+            }
         });
-        var format = {'element': 'Bylawlist'};
-        var style = new CKEDITOR.style(format);
-        editor.attachStyleStateChange( style, function( state ) {
-   	      !editor.readOnly && editor.getCommand( 'insertBylawlist' ).setState( state );
-        } );
-    }
+      };
+      const observer = new MutationObserver(observerCallback);
+
+      observer.observe(observerTarget, observerConfig);
+    });
+  }
 });


### PR DESCRIPTION
See https://github.com/CityofOttawa/ottawa_profile/issues/2244

Makes the numbers shift in the editor when you set the starting number.

Add a mutation observer to watch for changes to attributes (normal "change" events to trigger on attributes).

Only really works in Chrome but Vennila said it was fine cause their editors are told to use chrome.