### PR TITLE
Fix bylaw list styling issue

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -39,7 +39,10 @@ CKEDITOR.plugins.add( 'bylawlist', {
        * @param {object} obj the list object.
        */
       function updateList(obj) {
-        jQuery(obj).find('li').first().css('counter-reset', 'bylawlist-counter ' + (jQuery(obj).attr('start') - 1));
+        const start = jQuery(obj).attr('start') ? jQuery(obj).attr('start') - 1 : 0;
+
+        jQuery(obj).find('li').css('counter-reset', '');
+        jQuery(obj).find('li').first().css('counter-reset', `bylawlist-counter ${start}`);
       }
 
       const lists = editor.document.find('ol[start]');
@@ -51,12 +54,20 @@ CKEDITOR.plugins.add( 'bylawlist', {
       });
 
       const observerTarget = editor.document.find('html').$[0];
-      const observerConfig = { attributes: true, subtree: true };
+      const observerConfig = {
+        attributes: true,
+        subtree: true,
+        childList: true
+      };
       const observerCallback = (mutationsList, observer) => {
         mutationsList.forEach((mutation) => {
-            if (mutation.attributeName == 'start') {
-              updateList(mutation.target)
-            }
+          if (mutation.target.localName === 'ol' && (mutation.addedNodes.length > 0 || mutation.removedNodes.length > 0)) {
+            updateList(mutation.target);
+          }
+
+          if (mutation.attributeName == 'start') {
+            updateList(mutation.target)
+          }
         });
       };
       const observer = new MutationObserver(observerCallback);


### PR DESCRIPTION
Adds code to reset the counter-reset style to null on all list items aside from the first child of each list. 

This check will trigger whenever a "start" value is added/deleted/altered on a list, and whenever a list gains or loses a list item.

see https://github.com/CityofOttawa/ottawa_profile/issues/2341
---

Also refactored code to remove jQuery in favour of vanilla JS to improve performance.